### PR TITLE
Fix warnings in libwww2

### DIFF
--- a/libhtmlw/HTML.h
+++ b/libhtmlw/HTML.h
@@ -52,8 +52,8 @@
  * mosaic-x@ncsa.uiuc.edu.                                                  *
  ****************************************************************************/
 
-#ifndef HTML_H
-#define HTML_H
+#ifndef HTMLW_HTML_H
+#define HTMLW_HTML_H
 
 #ifdef MOTIF
 #include <Xm/Xm.h>
@@ -634,5 +634,5 @@ typedef struct _HTMLRec      *HTMLWidget;
 extern WidgetClass htmlWidgetClass;
 
 
-#endif /* HTML_H */
+#endif /* HTMLW_HTML_H */
 

--- a/libnut/str-tools.h
+++ b/libnut/str-tools.h
@@ -1,3 +1,4 @@
+int compact_string(char *main_string, char *ellipsis_string, int num_chars, int mode, int eLength);
 char *getFileName(char *file_src);
 char *strcasechr(char *src, char srch);
 char *strrcasechr(char *src, char srch);

--- a/libwww2/HTAABrow.c
+++ b/libwww2/HTAABrow.c
@@ -734,13 +734,13 @@ PRIVATE char *compose_auth_string ARGS2(HTAAScheme,	scheme,
 
 	if (!(result = (char*)malloc(300)))
 	    outofmem(__FILE__, "compose_auth_string");
-	
+
 	nonce = HTAssocList_lookup(setup->scheme_specifics[scheme], "nonce");
-	if (!nonce) 
+	if (!nonce)
 	    return "";
-	
+
 	opaque = HTAssocList_lookup(setup->scheme_specifics[scheme], "opaque");
-	if (!opaque) 
+	if (!opaque)
 	    return "";
 
 	if (!(A1 = (unsigned char*)malloc(strlen(realm->username) + 
@@ -753,22 +753,22 @@ PRIVATE char *compose_auth_string ARGS2(HTAAScheme,	scheme,
 
 	    /* make A1 */
 	*A1 = (unsigned char)0;
-	strcat(A1, realm->username);
-	strcat(A1, ":");
-	strcat(A1, realm->realmname);
-	strcat(A1, ":");
-	strcat(A1, realm->password);
-	strcat(A1, "\0");
+	strcat((char*)A1, realm->username);
+	strcat((char*)A1, ":");
+	strcat((char*)A1, realm->realmname);
+	strcat((char*)A1, ":");
+	strcat((char*)A1, realm->password);
+	strcat((char*)A1, "\0");
 
 	    /* make A2 */
 	*A2 = (unsigned char)0;
 	if (do_post)
-	    strcat(A2, "POST");
+	    strcat((char*)A2, "POST");
 	else
-	    strcat(A2, "GET");
-	strcat(A2, ":");
-	strcat(A2, current_docname);
-	strcat(A2, "\0");
+	    strcat((char*)A2, "GET");
+	strcat((char*)A2, ":");
+	strcat((char*)A2, current_docname);
+	strcat((char*)A2, "\0");
 
 	if (!(md5_cleartext = (unsigned char*)malloc(100 + 1)))
 	    outofmem(__FILE__, "compose_auth_string");	
@@ -783,8 +783,8 @@ PRIVATE char *compose_auth_string ARGS2(HTAAScheme,	scheme,
 	if (!(digest2 = (unsigned char*)malloc(16)))
 	    outofmem(__FILE__, "compose_auth_string");	
 	
-	MD5Mem(A1, strlen(A1), digest1);
-	MD5Mem(A2, strlen(A2), digest2);
+	MD5Mem(A1, strlen((char*)A1), digest1);
+	MD5Mem(A2, strlen((char*)A2), digest2);
 
 	MD5Convert_to_Hex(digest1, hex1);
 	MD5Convert_to_Hex(digest2, hex2);
@@ -792,13 +792,13 @@ PRIVATE char *compose_auth_string ARGS2(HTAAScheme,	scheme,
 	    /* make md5_cleartext */
 
 	*md5_cleartext = (unsigned char)0;
-	strcat(md5_cleartext, hex1);
-	strcat(md5_cleartext, ":");
-	strcat(md5_cleartext, nonce);
-	strcat(md5_cleartext, ":");
-	strcat(md5_cleartext, hex2);
+	strcat((char*)md5_cleartext, (char*)hex1);
+	strcat((char*)md5_cleartext, ":");
+	strcat((char*)md5_cleartext, (char*)nonce);
+	strcat((char*)md5_cleartext, ":");
+	strcat((char*)md5_cleartext, (char*)hex2);
 
-	MD5Mem(md5_cleartext, strlen(md5_cleartext), digest1);
+	MD5Mem(md5_cleartext, strlen((char*)md5_cleartext), digest1);
 	MD5Convert_to_Hex(digest1, md5_ciphertext);
 
 	*result = (char)0;
@@ -811,12 +811,12 @@ PRIVATE char *compose_auth_string ARGS2(HTAAScheme,	scheme,
 	strcat(result, "\", uri=\"");
 	strcat(result, current_docname);
 	strcat(result, "\", response=\"");
-	strcat(result, md5_ciphertext);
+	strcat(result, (char*)md5_ciphertext);
 	strcat(result, "\", opaque=\"");
 	strcat(result, opaque);
 	strcat(result, "\"");
 
-	/* since all we need from here on out is the result, 
+	/* since all we need from here on out is the result,
 	     get rid of all the rest */
 	free(A1);
 	free(A2);

--- a/libwww2/HTAAUtil.c
+++ b/libwww2/HTAAUtil.c
@@ -47,6 +47,7 @@
 #include "tcp.h"	/* NETREAD() etc.	*/
 #include "HTAAUtil.h"	/* Implemented here	*/
 #include "HTAssoc.h"	/* Assoc list		*/
+#include "HTTCP.h"
 
 #ifndef DISABLE_TRACE
 extern int www2Trace;

--- a/libwww2/HTAccess.c
+++ b/libwww2/HTAccess.c
@@ -41,7 +41,11 @@
 #include "HText.h"	/* See bugs above */
 #include "HTAlert.h"
 
+#include "../src/mosaic.h"
+#include "../src/gui.h"
+#include "../src/mo-www.h"
 #include "../src/proxy.h"
+#include "../src/proxy-dialogs.h"
 
 #ifndef DISABLE_TRACE
 extern int www2Trace;

--- a/libwww2/HTAlert.c
+++ b/libwww2/HTAlert.c
@@ -15,10 +15,8 @@
 #include "tcp.h"		/* for TOUPPER */
 #include <ctype.h> 		/* for toupper - should be in tcp.h */
 
-extern void mo_gui_notify_progress (char *);
-extern int mo_gui_check_icon (int);
-extern void mo_gui_clear_icon (void);
-extern void mo_gui_update_meter(int,char *);
+#include "../src/mosaic.h"
+#include "../src/gui.h"
 
 PUBLIC void HTAlert ARGS1(WWW_CONST char *, Msg)
 {

--- a/libwww2/HTAlert.h
+++ b/libwww2/HTAlert.h
@@ -28,7 +28,7 @@ extern char * HTPromptPassword PARAMS((WWW_CONST char * Msg));
 **              The input is a list of parameters for printf.
 */
 extern void HTAlert PARAMS((WWW_CONST char * Msg));
-
+extern void HTDoneWithIcon NOPARAMS;
 
 /*      Display a progress message for information (and diagnostics) only
 **
@@ -36,6 +36,7 @@ extern void HTAlert PARAMS((WWW_CONST char * Msg));
 **              The input is a list of parameters for printf.
 */
 extern void HTProgress PARAMS((WWW_CONST char * Msg));
+extern void HTMeter PARAMS((WWW_CONST int, WWW_CONST char *));
 extern int HTCheckActiveIcon PARAMS((int twirl));
 extern void HTClearActiveIcon NOPARAMS;
 

--- a/libwww2/HTAnchor.c
+++ b/libwww2/HTAnchor.c
@@ -96,9 +96,9 @@ PUBLIC HTChildAnchor * HTAnchor_findChild
 #endif
     return NULL;
   }
-  if (kids = parent->children) {  /* parent has children : search them */
+  if ((kids = parent->children)) {  /* parent has children : search them */
     if (tag && *tag) {		/* TBL */
-	while (child = HTList_nextObject (kids)) {
+	while ((child = HTList_nextObject (kids))) {
 	    if (equivalent(child->tag, tag)) { /* Case sensitive 920226 */
 #ifndef DISABLE_TRACE
 		if (www2Trace) fprintf (stderr,
@@ -115,7 +115,7 @@ PUBLIC HTChildAnchor * HTAnchor_findChild
   child = HTChildAnchor_new ();
 #ifndef DISABLE_TRACE
   if (www2Trace) fprintf(stderr, "new Anchor %p named `%s' is child of %p\n",
-       (void*)child, (int)tag ? tag : (WWW_CONST char *)"" , (void*)parent); /* int for apollo */
+       (void*)child, tag == NULL ? tag : (WWW_CONST char *)"" , (void*)parent); /* int for apollo */
 #endif
   HTList_addObject (parent->children, child);
   child->parent = parent;
@@ -201,7 +201,7 @@ HTAnchor * HTAnchor_findAddress
 
     /* Search list for anchor */
     grownups = adults;
-    while (foundAnchor = HTList_nextObject (grownups)) {
+    while ((foundAnchor = HTList_nextObject (grownups))) {
        if (equivalent(foundAnchor->address, address)) {
 #ifndef DISABLE_TRACE
 	if (www2Trace) fprintf(stderr, "Anchor %p with address `%s' already exists.\n",

--- a/libwww2/HTCompressed.c
+++ b/libwww2/HTCompressed.c
@@ -21,6 +21,9 @@
 
 #include "../libnut/system.h"
 
+#include "../src/mosaic.h"
+#include "../src/mo-www.h"
+
 #ifndef DISABLE_TRACE
 extern int www2Trace;
 #endif

--- a/libwww2/HTFTP.c
+++ b/libwww2/HTFTP.c
@@ -43,10 +43,13 @@
 #include <string.h>
 #include <stdlib.h>
 #include <time.h>
+#include <unistd.h>
+
 #include "HTFTP.h"	/* Implemented here */
 #include "../libnut/str-tools.h"
 #define LINE_LENGTH 1024
 
+#include "HTAlert.h"
 #include "HTParse.h"
 #include "HTUtils.h"
 #include "tcp.h"
@@ -56,6 +59,10 @@
 #include "HTChunk.h"
 #include "HTSort.h"
 #include "HText.h"
+
+#include "../src/mosaic.h"
+#include "../src/gui.h"
+#include "../src/gui-dialogs.h"
 
 #ifndef MAXHOSTNAMELEN
 #define MAXHOSTNAMELEN 64           /* Arbitrary limit */
@@ -124,6 +131,8 @@ extern int ftpRedialSleep;
 extern int ftpFilenameLength;
 extern int ftpEllipsisLength;
 extern int ftpEllipsisMode;
+
+void CLOSE_CONTROL(int);
 
 /*SWP -- 9.27.95 -- Directory parsing*/
 #define NEW_PARSE
@@ -1042,7 +1051,7 @@ PRIVATE int get_listen_socket()
   sin->sin_addr.s_addr = INADDR_ANY; /* Any peer address */
   {
     int status;
-    int address_length = sizeof(soc_address);
+    socklen_t address_length = sizeof(soc_address);
 #ifdef SOCKS
     status = Rgetsockname(control,
 #else
@@ -1878,7 +1887,7 @@ skipDir:
   {
     struct sockaddr_in soc_address;
 
-    int	soc_addrlen = sizeof(soc_address);
+    socklen_t soc_addrlen = sizeof(soc_address);
 #ifdef SOCKS
     status = Raccept(master_socket,
 #else
@@ -2271,7 +2280,7 @@ PUBLIC int HTFTPSend ARGS1 ( char *, name ) {
  extern int twirl_increment;
  int next_twirl = twirl_increment, intr = 0;
  struct sockaddr_in soc_address;
- int soc_addrlen = sizeof (soc_address);
+ socklen_t soc_addrlen = sizeof (soc_address);
  struct stat sbuf;
  
         HTProgress ("FTP send in progress.");
@@ -2501,7 +2510,7 @@ PUBLIC int HTFTPSend ARGS1 ( char *, name ) {
 } /* End of HTFTPSend */
 
 
-CLOSE_CONTROL(s)
+void CLOSE_CONTROL(s)
 int s;
 {
 	NETCLOSE(s);

--- a/libwww2/HTFWriter.c
+++ b/libwww2/HTFWriter.c
@@ -9,6 +9,7 @@
 */
 #include "../config.h"
 #include <string.h>
+#include <unistd.h>
 
 #include "HTFWriter.h"
 
@@ -18,6 +19,12 @@
 #include "HText.h"
 #include "tcp.h"
 #include "HTCompressed.h"
+
+#include "../libhtmlw/HTML.h"
+
+#include "../src/mosaic.h"
+#include "../src/gui-dialogs.h"
+#include "../src/img.h"
 
 extern char *currentURL;
 
@@ -245,7 +252,7 @@ PRIVATE void HTFWriter_free ARGS1(HTStream *, me)
 
 			buf=(char *)calloc((strlen(currentURL)+strlen(me->fnam)+5),sizeof(char));
 			sprintf(buf,"%s\n%s",me->fnam,currentURL);
-			ImageResolve(NULL,buf,0);
+			ImageResolve(NULL,buf,0,NULL,NULL);
 
 			free(buf);
 

--- a/libwww2/HTFile.c
+++ b/libwww2/HTFile.c
@@ -23,6 +23,8 @@
 
 #include <stdio.h>
 #include <sys/param.h>
+#include <unistd.h>
+
 #include "HText.h"
 #include "HTUtils.h"
 
@@ -36,7 +38,9 @@
 #include "HTFWriter.h"
 #include "HTInit.h"
 #include "HTSort.h"
+
 #include "../libnut/system.h"
+#include "../libnut/str-tools.h"
 
 typedef struct _HTSuffix {
 	char *		suffix;
@@ -729,7 +733,7 @@ PUBLIC BOOL HTEditable ARGS1 (WWW_CONST char *,filename)
 #ifdef NO_GROUPS
     return NO;		/* Safe answer till we find the correct algorithm */
 #else
-    int 	groups[NGROUPS];	
+    gid_t 	groups[NGROUPS];	
     uid_t	myUid;
     int		ngroups;			/* The number of groups  */
     struct stat	fileStatus;
@@ -1165,8 +1169,8 @@ forget_multi:
                     if(strcmp(dataptr,".") == 0) continue;
  
 /* If its .. *and* the current directory is / dont show anything, otherwise
-/* print out a nice Parent Directory entry.
-/* */
+ * print out a nice Parent Directory entry.
+ * */
 
                     if(strcmp(dataptr,"..") == 0)
                         {
@@ -1227,8 +1231,8 @@ forget_multi:
                         }
                     else
                         {
-                        sprintf(buffer,"%s (%d bytes)", 
-                            dataptr, statbuf.st_size);
+                        sprintf(buffer,"%s (%ld bytes)", 
+                            dataptr, (long)statbuf.st_size);
               
                         format = HTFileFormat(dataptr, &pencoding, 
                                      WWW_SOURCE, &cmpr);

--- a/libwww2/HTFormat.c
+++ b/libwww2/HTFormat.c
@@ -2,6 +2,8 @@
 **		=============================
 **
 */
+#include <unistd.h>
+
 #include "../config.h"
 /* Connection: Keep-Alive support -bjs */
 #include "HTMIME.h"
@@ -24,6 +26,7 @@ PUBLIC float HTMaxLength = 1e10;	/* No effective limit */
 #include "SGML.h"
 #include "HTML.h"
 #include "HTMLGen.h"
+#include "HTTCP.h"
 
 /* From gui-documents.c. */
 extern int loading_inlined_images;

--- a/libwww2/HTGopher.c
+++ b/libwww2/HTGopher.c
@@ -47,7 +47,7 @@
 #include "HTUtils.h"		/* Coding convention macros */
 #include "tcp.h"
 
-
+#include "HTAlert.h"
 #include "HTParse.h"
 #include "HTFormat.h"
 #include "HTFile.h"

--- a/libwww2/HTInit.c
+++ b/libwww2/HTInit.c
@@ -17,6 +17,8 @@
 extern int www2Trace;
 #endif
 
+int HTLoadTypesConfigFile(char *);
+
 /* Reread config files. */
 PUBLIC void HTReInit NOARGS
 {
@@ -220,7 +222,7 @@ static char *Cleanse(char *s) /* no leading or trailing space, all lower case */
     return(news);
 }
 
-static ProcessMailcapEntry(FILE *fp, struct MailcapEntry *mc)
+static int ProcessMailcapEntry(FILE *fp, struct MailcapEntry *mc)
 {
     int rawentryalloc = 2000, len;
     char *rawentry, *s, *t, *LineBuf;
@@ -294,7 +296,7 @@ static ProcessMailcapEntry(FILE *fp, struct MailcapEntry *mc)
 }
 
 
-static ProcessMailcapFile(char *file)
+static int ProcessMailcapFile(char *file)
 {
     struct MailcapEntry mc;
     FILE *fp;
@@ -534,6 +536,7 @@ static void getword(char *word, char *line, char stop, char stop2)
 int HTLoadExtensionsConfigFile (char *fn)
 {
   char l[MAX_STRING_LEN],w[MAX_STRING_LEN],*ct,*ptr;
+  size_t len = MAX_STRING_LEN;
   FILE *f;
   int x, count = 0;
 
@@ -553,7 +556,7 @@ int HTLoadExtensionsConfigFile (char *fn)
       return -1;
     }
 
-  while(!(getline(l,MAX_STRING_LEN,f))) 
+  while(!(getline((char**)&l,&len,f))) 
     {
       /* always get rid of leading white space for "line" -- SWP */
       for (ptr=l; *ptr && isspace(*ptr); ptr++);

--- a/libwww2/HTMIME.c
+++ b/libwww2/HTMIME.c
@@ -585,7 +585,7 @@ PRIVATE void HTMIME_put_character ARGS2(HTStream *, me, char, c)
               me->format = HTAtom_for(me->value);
 #ifndef DISABLE_TRACE
               if (www2Trace)
-                fprintf (stderr, "[MIME_put_char] Got content-type value atom 0x%08x\n",
+                fprintf (stderr, "[MIME_put_char] Got content-type value atom %p\n",
                          me->format);
 #endif
               break;
@@ -595,7 +595,7 @@ PRIVATE void HTMIME_put_character ARGS2(HTStream *, me, char, c)
               if (www2Trace)
                 fprintf (stderr, 
                          "[MIME_put_char] Picked up transfer_encoding '%s'\n",
-                         me->encoding);
+                         (char*)me->encoding);
 #endif
               break;
             case CONTENT_ENCODING:
@@ -887,18 +887,18 @@ PRIVATE void HTMIME_free ARGS1(HTStream *, me)
 #endif
 #ifndef DISABLE_TRACE
       if (www2Trace)
-        fprintf (stderr, "  me 0x%08x, me->target 0x%08x\n", me, me->target);
+        fprintf (stderr, "  me %p, me->target %p\n", me, me->target);
 #endif
       me->format = HTAtom_for ("text/html");
       me->target = HTStreamStack(me->format, me->targetRep, 0,
                                  me->sink, me->anchor);
 #ifndef DISABLE_TRACE
       if (www2Trace)
-        fprintf (stderr, "  me->target->isa 0x%08x\n", me->target->isa);
+        fprintf (stderr, "  me->target->isa %p\n", me->target->isa);
 #endif
 #ifndef DISABLE_TRACE
       if (www2Trace)
-        fprintf (stderr, "  *me->target->isa 0x%08x\n", *me->target->isa);
+        fprintf (stderr, "  me->target->isa->name %s\n", me->target->isa->name);
 #endif
       me->targetClass = *me->target->isa;
       (*me->targetClass.put_string) (me->target, "<H1>ERROR IN HTTP/1.0 RESPONSE</H1> The remote server returned a HTTP/1.0 response that Mosaic's MIME parser could not understand.  Please contact the server maintainer.<P> Sorry for the inconvenience,<P> <ADDRESS>The Management</ADDRESS>");

--- a/libwww2/HTMailto.c
+++ b/libwww2/HTMailto.c
@@ -10,12 +10,15 @@
  */
 #include "../config.h"
 #include "HTAccess.h"
+#include "HTAlert.h"
 #include "HTUtils.h"
 #include "tcp.h"
 #include "HTML.h"
 #include "HTParse.h"
 #include "HTFormat.h"
 #include "../libnut/str-tools.h"
+#include "../src/mosaic.h"
+#include "../src/mailto.h"
 #ifndef DISABLE_TRACE
 extern int www2Trace;
 #endif

--- a/libwww2/HTParse.c
+++ b/libwww2/HTParse.c
@@ -238,7 +238,7 @@ char * HTParse(aName, relatedName, wanted)
                   {
 #ifndef DISABLE_TRACE
                     if (www2Trace)
-                      fprintf (stderr, "[Parse] Copying '%s' to '%s', %d bytes\n", 
+                      fprintf (stderr, "[Parse] Copying '%s' to '%s', %zu bytes\n", 
                                p+1, p, strlen (p+1));
 #endif
 /*

--- a/libwww2/HTTP.c
+++ b/libwww2/HTTP.c
@@ -4,6 +4,9 @@
 #include "../config.h"
 #include "HTTP.h"
 
+#include "../src/mosaic.h"
+#include "../src/mo-www.h"
+
 #define HTTP_VERSION	"HTTP/1.0"
 
 #define INIT_LINE_SIZE		1024	/* Start with line buffer this big */

--- a/libwww2/HTUU.c
+++ b/libwww2/HTUU.c
@@ -148,21 +148,21 @@ PUBLIC int HTUU_decode ARGS3(char *,		bufcoded,
 
       for(j=0; j<64; j++) pr2six[six2pr[j]] = (unsigned char) j;
 #if 0
-      pr2six['A']= 0; pr2six['B']= 1; pr2six['C']= 2; pr2six['D']= 3; 
-      pr2six['E']= 4; pr2six['F']= 5; pr2six['G']= 6; pr2six['H']= 7; 
-      pr2six['I']= 8; pr2six['J']= 9; pr2six['K']=10; pr2six['L']=11; 
-      pr2six['M']=12; pr2six['N']=13; pr2six['O']=14; pr2six['P']=15; 
-      pr2six['Q']=16; pr2six['R']=17; pr2six['S']=18; pr2six['T']=19; 
-      pr2six['U']=20; pr2six['V']=21; pr2six['W']=22; pr2six['X']=23; 
-      pr2six['Y']=24; pr2six['Z']=25; pr2six['a']=26; pr2six['b']=27; 
-      pr2six['c']=28; pr2six['d']=29; pr2six['e']=30; pr2six['f']=31; 
-      pr2six['g']=32; pr2six['h']=33; pr2six['i']=34; pr2six['j']=35; 
-      pr2six['k']=36; pr2six['l']=37; pr2six['m']=38; pr2six['n']=39; 
-      pr2six['o']=40; pr2six['p']=41; pr2six['q']=42; pr2six['r']=43; 
-      pr2six['s']=44; pr2six['t']=45; pr2six['u']=46; pr2six['v']=47; 
-      pr2six['w']=48; pr2six['x']=49; pr2six['y']=50; pr2six['z']=51; 
-      pr2six['0']=52; pr2six['1']=53; pr2six['2']=54; pr2six['3']=55; 
-      pr2six['4']=56; pr2six['5']=57; pr2six['6']=58; pr2six['7']=59; 
+      pr2six['A']= 0; pr2six['B']= 1; pr2six['C']= 2; pr2six['D']= 3;
+      pr2six['E']= 4; pr2six['F']= 5; pr2six['G']= 6; pr2six['H']= 7;
+      pr2six['I']= 8; pr2six['J']= 9; pr2six['K']=10; pr2six['L']=11;
+      pr2six['M']=12; pr2six['N']=13; pr2six['O']=14; pr2six['P']=15;
+      pr2six['Q']=16; pr2six['R']=17; pr2six['S']=18; pr2six['T']=19;
+      pr2six['U']=20; pr2six['V']=21; pr2six['W']=22; pr2six['X']=23;
+      pr2six['Y']=24; pr2six['Z']=25; pr2six['a']=26; pr2six['b']=27;
+      pr2six['c']=28; pr2six['d']=29; pr2six['e']=30; pr2six['f']=31;
+      pr2six['g']=32; pr2six['h']=33; pr2six['i']=34; pr2six['j']=35;
+      pr2six['k']=36; pr2six['l']=37; pr2six['m']=38; pr2six['n']=39;
+      pr2six['o']=40; pr2six['p']=41; pr2six['q']=42; pr2six['r']=43;
+      pr2six['s']=44; pr2six['t']=45; pr2six['u']=46; pr2six['v']=47;
+      pr2six['w']=48; pr2six['x']=49; pr2six['y']=50; pr2six['z']=51;
+      pr2six['0']=52; pr2six['1']=53; pr2six['2']=54; pr2six['3']=55;
+      pr2six['4']=56; pr2six['5']=57; pr2six['6']=58; pr2six['7']=59;
       pr2six['8']=60; pr2six['9']=61; pr2six['+']=62; pr2six['/']=63;
 #endif
    }
@@ -175,7 +175,7 @@ PUBLIC int HTUU_decode ARGS3(char *,		bufcoded,
     * If this would decode into more bytes than would fit into
     * the output buffer, adjust the number of input bytes downwards.
     */
-   bufin = bufcoded;
+   bufin = (unsigned char *) bufcoded;
    while(pr2six[*(bufin++)] <= MAXVAL);
    nprbytes = bufin - ((unsigned char *)bufcoded) - 1;
    nbytesdecoded = ((nprbytes+3)/4) * 3;
@@ -183,7 +183,7 @@ PUBLIC int HTUU_decode ARGS3(char *,		bufcoded,
       nprbytes = (outbufsize*4)/3;
    }
 
-   bufin = bufcoded;
+   bufin = (unsigned char *) bufcoded;
    
    while (nprbytes > 0) {
       *(bufout++) = (unsigned char) (DEC(*bufin) << 2 | DEC(bufin[1]) >> 4);

--- a/libwww2/SGML.c
+++ b/libwww2/SGML.c
@@ -13,6 +13,7 @@
 
 #include <ctype.h>
 #include <stdio.h>
+#include <string.h>
 #include "HTUtils.h"
 #include "HTChunk.h"
 #include "../libnut/str-tools.h"

--- a/libwww2/tcp.h
+++ b/libwww2/tcp.h
@@ -50,6 +50,7 @@ Default values
 
 #ifdef unix
 #define GOT_PIPE
+#include <unistd.h>
 #endif
 
 typedef struct sockaddr_in SockA;  /* See netinet/in.h */

--- a/makefiles/Makefile.linux
+++ b/makefiles/Makefile.linux
@@ -225,7 +225,9 @@ customflags =
 
 # ---------------------- END OF CUSTOMIZABLE OPTIONS -------------------------
 
-CFLAGS = -g $(sysconfigflags) $(prereleaseflags)
+# Disable certain warnings as we don't care for them
+CWARNINGS = -Wno-parentheses -Wno-switch-enum
+CFLAGS = -g $(sysconfigflags) $(prereleaseflags) $(CWARNINGS)
 
 # Don't worry about these -- for development purposes only.
 PURIFY = purify

--- a/src/img.c
+++ b/src/img.c
@@ -52,13 +52,13 @@
  * mosaic-x@ncsa.uiuc.edu.                                                  *
  ****************************************************************************/
 #include "../config.h"
+#include "../libhtmlw/HTML.h"
 #include "mosaic.h"
 #include "gui.h"
 #include "img.h"
 #include "mo-www.h"
 #include "globalhist.h"
 #include "picread.h"
-#include "libhtmlw/HTML.h"
 #include "cci.h"
 extern int cci_event;
 

--- a/src/img.h
+++ b/src/img.h
@@ -66,8 +66,11 @@
 #ifndef __IMG_H__
 #define __IMG_H__
 
+#include "../libhtmlw/HTML.h"
+
 mo_status mo_free_image_data (void *);
 mo_status mo_register_image_resolution_function (mo_window *);
+ImageInfo *ImageResolve (Widget w, char *src, int noload, char *wid, char *hei);
 
 #endif
 

--- a/src/mailto.h
+++ b/src/mailto.h
@@ -52,7 +52,7 @@
  * mosaic-x@ncsa.uiuc.edu.                                                  *
  ****************************************************************************/
 
-/* 
+/*
  * Created: Wed Apr 10 17:41:00 CDT 1996
  * Author: Dan Pape
  *
@@ -63,4 +63,4 @@
    the source whenever something changed. */
 
 
-
+mo_status mo_post_mailto_win (char *to_address, char *subject);

--- a/src/newsrc.h
+++ b/src/newsrc.h
@@ -95,7 +95,9 @@ newsgroup_t *addgroup (char *, long, long, int);
 newsgroup_t *firstgroup ();
 newsgroup_t *nextgroup (newsgroup_t *);
 void news_refreshprefs (void);
-
+void setminmax(newsgroup_t *ng,long min, long max);
+void rereadseq(newsgroup_t *ng);
+int newsrc_init(char *newshost);
 int newsrc_kill (void);
 
 #endif

--- a/src/proxy-dialogs.h
+++ b/src/proxy-dialogs.h
@@ -62,5 +62,4 @@
    that file up because it was too big, and required a re-compile of all
    the source whenever something changed. */
 
-
-
+void ClearTempBongedProxies();


### PR DESCRIPTION
These patches fix some warnings in the libwww2 directory which should now compile without any warnings at all. This is the first step to refurbish the source code in a way that no warnings remain.
